### PR TITLE
Fix DPS calculation

### DIFF
--- a/app/js/dps.js
+++ b/app/js/dps.js
@@ -108,7 +108,7 @@ unitDb.NotNukeDpsCalculator = angular.extend({}, unitDb.DpsCalculator, {
             return (s.shots * w.Damage * s.dotPulse) / s.cycle;
         }
 
-        var trueReload = Math.max(0.1*Math.floor((10 / w.RateOfFire) + 0.5), 0.1); //the rof is rounded to the nearest tick since the game runs in ticks.
+        var trueReload = Math.max(0.1*Math.floor(10 / w.RateOfFire), 0.1); //the rof is rounded down to the nearest tick since the game runs in ticks. (eg. If the unit's RoF is 0.8 it should shoot every 1.25 second but it shoots every 1.2 second.)
         // some weapons also have separate charge and reload times which results in them firing less often. yeah.
         // in theory if your total MuzzleSalvoDelay is longer than the reload time your weapon waits for the reload time twice, but thats pretty much a bug so not taken into account here
         trueReload = Math.max((w.RackSalvoChargeTime || 0) + (w.RackSalvoReloadTime || 0) + (w.MuzzleSalvoDelay || 0)*((w.MuzzleSalvoSize || 1)-1), trueReload);


### PR DESCRIPTION
Fixes the standard DPS calculation. The RoF is rounded down (not rounded to) to the nearest tick.

The check fails because the value in the test is wrong, it should be 16.07 (that's DPS per 1 projectile while Zthuee has 5 so the actual DPS of the unit is 80.36)