### PR TITLE
Fix the URL to the Github repository

### DIFF
--- a/app/views/unit.html
+++ b/app/views/unit.html
@@ -4,7 +4,7 @@
             <span class="strategic icon-{{ item.faction  }}_{{ item.strategicIcon}}" ></span>
         </span>
         <h1>{{ item.fullName }}</h1>
-        <a href="https://github.com/FAForever/fa/blob/develop/units/{{ item.id }}/{{ item.id }}_unit.bp" target="_blank"><small>{{ item.id }}</small></a>
+        <a href="https://github.com/FAForever/fa/blob/deploy/fafdevelop/units/{{ item.id }}/{{ item.id }}_unit.bp" target="_blank"><small>{{ item.id }}</small></a>
     </header>
     <section>
         <table>


### PR DESCRIPTION
This has been broken for years. The main branch has been `deploy/fafdevelop` for a long time now.

See also: https://github.com/FAForever/fa/issues/5260

