### PR TITLE
Add generate action file for unit database

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -20,8 +20,7 @@
 
 name: generate
 
-on:
-    workflow_dispatch:
+on: push
 
 jobs:
     generate:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 Aaron 'relent0r' Warner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: generate
+
+on:
+    workflow_dispatch:
+
+jobs:
+    generate:
+        name: generate
+        permissions: write-all
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout spooky db code
+              uses: actions/checkout@v4
+
+            - name: Checkout FAForever blueprints and lua files
+              uses: actions/checkout@v4
+              with:
+                  repository: FAForever/fa
+                  path: fa
+                  sparse-checkout-cone-mode: false
+                  sparse-checkout: |
+                      *.bp
+                      *.lua
+
+            - name: Checkout Nomads blueprints and lua files
+              uses: actions/checkout@v4
+              with:
+                  repository: FAForever/nomads
+                  path: nomads
+                  sparse-checkout-cone-mode: false
+                  sparse-checkout: |
+                      *.bp
+
+            # Prepare the Lua context
+
+            - name: Install Lua
+              uses: leafo/gh-actions-lua@v10
+              with:
+                  luaVersion: "5.1.5"
+
+            - uses: leafo/gh-actions-luarocks@v4
+
+            - name: Install JSON module for Lua
+              run: luarocks install dkjson
+
+            # Prepare the script context
+
+            - name: Prepare for the script
+              shell: bash
+              run: |
+                  mkdir tools/temp
+                  mkdir tools/temp/units
+                  mkdir tools/temp/lua
+
+                  mv -f fa/units/* tools/temp/units
+                  mv -f nomads/units/* tools/temp/units
+                  mv fa/lua/version.lua tools/temp/lua/version.lua
+
+            - name: Run the script
+              shell: pwsh
+              working-directory: tools # script expects this directory
+              run: |
+                  lua -v
+                  pwsh ./index.ps1 -target ../app -inputUnits "temp/units" -inputLua "temp/lua"
+
+            # Store the created files
+
+            - name: Create artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Generated files
+                  path: |
+                      app/data

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -20,7 +20,8 @@
 
 name: generate
 
-on: push
+on:
+    workflow_dispatch:
 
 jobs:
     generate:


### PR DESCRIPTION
Description of changes
This PR adds a generate action which is a cut down version of the current update action. It will generate the the unit index and upload the resulting artifact for a future action.

Testing method
Manual action requires to be taken on the default branch. Have tested with a push trigger to validate that the artifact and contents were created.

closes #124 