### PR TITLE
Update build action to leverage generate artifact

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -1,0 +1,32 @@
+# Debug workflows locally
+
+## Prerequisites
+
+- (1) [Github CLI](https://github.com/cli/cli)
+
+Verify that Github CLI is installed and available via `gh --version`. You need to authorize yourself via `gh login`. Once authorised, verify that `gh auth token` returns a value. You'll need that token to authorize yourself through `act`.
+
+- (2) [Act](https://github.com/nektos/act)
+
+Verify that act is installed and available via `act --version`. There are [various ways](https://nektosact.com/installation/index.html) to install it via a tool, downloading the artifact that matches your OS and adding it to the path is sufficient however.
+
+- (3) [Docker](https://www.docker.com/products/docker-desktop/)
+
+Verify that docker is installed and available via `docker --version`.  Act uses docker containers to containerize your workflows. You'll need to start the `Docker Desktop` application to guarantee that the docker engine is running.
+
+## Debug a workflow
+
+The tool `act` only works on workflows that have the `push` event. Add the `push` event to the workflow that you want to test if it is missing.
+
+```bash
+    #   # Non-standard image that has `pwsh` installed            # Workflow to debug               # Token to authorize
+    act -P 'ubuntu-latest=ghcr.io/catthehacker/ubuntu:pwsh-22.04' -W '.github/workflows/build.yaml' -s GITHUB_TOKEN="$(gh auth token)"
+
+    # for repeated tests                                                                                                               # do not pull (-p) the docker image each time
+    act -P 'ubuntu-latest=ghcr.io/catthehacker/ubuntu:pwsh-22.04' -W '.github/workflows/build.yaml' -s GITHUB_TOKEN="$(gh auth token)" -p=false
+```
+
+Useful references:
+
+- [Documentation about act](https://nektosact.com/introduction.html)
+- [List of all official docker images](https://github.com/catthehacker/docker_images)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
                 name: spookydb-generated-files
 
             - name: Display structure of downloaded files
-              run: ls -R
+              run: ls ./app/data -l
 
             # https://github.com/actions/setup-node/tree/main
             - name: Use Node.js 20.x

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,7 @@ jobs:
 
             - name: Install
               run: |
+                  git diff
                   npm install
                   npm install bower
                   npm install grunt-cli

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
     call-workflow-generate-in-local-repo:
       uses: ./.github/workflows/generate.yaml
     build:
+        needs: [call-workflow-generate-in-local-repo]
         name: build application
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ on:
     push:
 
 jobs:
-    call-workflow-2-in-local-repo:
+    call-workflow-generate-in-local-repo:
       uses: ./.github/workflows/generate.yaml
     build:
         name: build application

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,22 +23,25 @@ name: build
 on:
     workflow_dispatch:
     workflow_call:
+    push:
 
 jobs:
-    call-workflow-generate-in-local-repo:
-      uses: ./.github/workflows/generate.yaml
+    update:
+        uses: ./.github/workflows/generate.yaml
     build:
-        needs: [call-workflow-generate-in-local-repo]
+        needs: [update]
         name: build application
         runs-on: ubuntu-latest
         steps:
             # https://github.com/actions/checkout/tree/v4/
             - name: Checkout spooky db code
               uses: actions/checkout@v4
+              with: 
+                  ref: master
 
             - uses: actions/download-artifact@v4
               with:
-                name: spookydb-generated-files
+                  name: spookydb-generated-files
 
             # https://github.com/actions/setup-node/tree/main
             - name: Use Node.js 20.x

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,9 +39,6 @@ jobs:
               with:
                 name: spookydb-generated-files
 
-            - name: Display structure of downloaded files
-              run: ls ./app/data -l
-
             # https://github.com/actions/setup-node/tree/main
             - name: Use Node.js 20.x
               uses: actions/setup-node@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,9 +21,11 @@
 name: build
 
 on:
-    workflow_dispatch:
+    push:
 
 jobs:
+    call-workflow-2-in-local-repo:
+      uses: ./.github/workflows/generate.yaml
     build:
         name: build application
         runs-on: ubuntu-latest
@@ -31,6 +33,13 @@ jobs:
             # https://github.com/actions/checkout/tree/v4/
             - name: Checkout spooky db code
               uses: actions/checkout@v4
+
+            - uses: actions/download-artifact@v4
+              with:
+                name: spookydb-generated-files
+
+            - name: Display structure of downloaded files
+              run: ls -R
 
             # https://github.com/actions/setup-node/tree/main
             - name: Use Node.js 20.x

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,12 @@ jobs:
               with: 
                   ref: master
 
+            - name: Remove old data
+              run: |
+                rm app/data/*.json
+                ls -R
+                git diff
+                
             - uses: actions/download-artifact@v4
               with:
                   name: spookydb-generated-files

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,13 +39,12 @@ jobs:
               with: 
                   ref: master
 
-            - name: Remove old data
+            - name: Remove existing unit information
               run: |
                 rm app/data/*.json
-                ls -R
-                git diff
                 
-            - uses: actions/download-artifact@v4
+            - name: Download recent unit information
+              uses: actions/download-artifact@v4
               with:
                   name: spookydb-generated-files
                   path: app/data
@@ -59,8 +58,6 @@ jobs:
 
             - name: Install
               run: |
-                  ls -R
-                  git diff
                   npm install
                   npm install bower
                   npm install grunt-cli

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: spookydb-generated-files
+                  path: app/data
 
             # https://github.com/actions/setup-node/tree/main
             - name: Use Node.js 20.x
@@ -52,6 +53,7 @@ jobs:
 
             - name: Install
               run: |
+                  ls -R
                   git diff
                   npm install
                   npm install bower

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,8 @@
 name: build
 
 on:
-    push:
+    workflow_dispatch:
+    workflow_call:
 
 jobs:
     call-workflow-generate-in-local-repo:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ name: build
 on:
     workflow_dispatch:
     workflow_call:
-    push:
 
 jobs:
     update:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -30,14 +30,18 @@ jobs:
         permissions: write-all
         runs-on: ubuntu-latest
         steps:
+            # Checking repositories
             - name: Checkout spooky db code
               uses: actions/checkout@v4
+              with:
+                  ref: master
 
             - name: Checkout FAForever blueprints and lua files
               uses: actions/checkout@v4
               with:
                   repository: FAForever/fa
                   path: fa
+                  ref: deploy/faf
                   sparse-checkout-cone-mode: false
                   sparse-checkout: |
                       *.bp
@@ -48,6 +52,7 @@ jobs:
               with:
                   repository: FAForever/nomads
                   path: nomads
+                  ref: master
                   sparse-checkout-cone-mode: false
                   sparse-checkout: |
                       *.bp
@@ -78,11 +83,12 @@ jobs:
                   mv fa/lua/version.lua tools/temp/lua/version.lua
 
             - name: Run the script
-              shell: pwsh
+              shell: bash
               working-directory: tools # script expects this directory
               run: |
-                  lua -v
+                  echo "pre-test"
                   pwsh ./index.ps1 -target ../app -inputUnits "temp/units" -inputLua "temp/lua"
+                  echo "post-test"
 
             # Store the created files
 

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -22,6 +22,7 @@ name: generate
 
 on:
     workflow_dispatch:
+    workflow_call:
 
 jobs:
     generate:
@@ -88,6 +89,6 @@ jobs:
             - name: Create artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: Generated files
+                  name: spookydb-generated-files
                   path: |
                       app/data

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -86,9 +86,7 @@ jobs:
               shell: bash
               working-directory: tools # script expects this directory
               run: |
-                  echo "pre-test"
                   pwsh ./index.ps1 -target ../app -inputUnits "temp/units" -inputLua "temp/lua"
-                  echo "post-test"
 
             # Store the created files
 

--- a/tools/index.ps1
+++ b/tools/index.ps1
@@ -11,6 +11,10 @@ param (
     [string]$inputLua = ""
 )
 
+Write-Output "target: $target"
+Write-Output "inputUnits: $inputUnits"
+Write-Output "inputLua: $inputLua"
+
 $env:Path -split ';'
 
 Function Create-UnitIndex {
@@ -21,29 +25,29 @@ Function Create-UnitIndex {
 
     $version = lua getVersion.lua "$luaVersionFile"
 
-    echo '{'
-    echo "`"version`": `"$version`","
+    Write-Output '{'
+    Write-Output "`"version`": `"$version`","
 
     $blueprints = Get-ChildItem "$unitDir\**\*_unit.bp"
     $count = 1
     $total = $blueprints.Count
 
-    echo '"units": '
-    echo '['
+    Write-Output '"units": '
+    Write-Output '['
     $blueprints | Foreach-Object {
         $file = $_.BaseName
         Write-Progress -Activity "Parsing $file" -Status "($count/$total)"
 
         lua blueprint2json.lua $_.FullName
         if ($count -lt $total) {
-            echo ','
+            Write-Output ','
         }
 
         $count++
     }
-    echo ']'
+    Write-Output ']'
 
-    echo '}'
+    Write-Output '}'
 }
 
 Function Create-Version {
@@ -53,7 +57,7 @@ Function Create-Version {
 
     $version = lua getVersion.lua "$luaVersionFile"
 
-    echo "{ `"version`": `"$version`" }"
+    Write-Output "{ `"version`": `"$version`" }"
 }
 
 Function Run {


### PR DESCRIPTION
Description of changes
This PR updates the build action to leverage the generate artifact. It will trigger the generate action then use the artifact output in its processing. Then upload another artifact of its own output for deployment.

Testing method
Manual action requires to be taken on the default branch. Have tested with a push trigger to validate that the artifact and contents were created.

During testing you can see the actions being validated in my fork https://github.com/relent0r/spooky-db

closes #125 